### PR TITLE
サーバーが立ち上がったログに日時を出力するよう変更

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,5 +14,5 @@ const server = http.createServer((req, res) => {
 });
 const port = 8000;
 server.listen(port, () => {
-	console.log('Listening on ' + port);
+	console.info('[' + new Date() + '] Listening on ' + port);
 });


### PR DESCRIPTION
### tmuxのセッションが増えてしまったとき

↑
tmuxないで、cntr + b => d　でデタッチすると、セッションが残る。
セッションが残ったまま、tmuxを再度実行すると、tmuxのセッションが増えていく


↑
tmux -attach
を実行すると、ひとつ前のセッションにアタッチすることができる。
